### PR TITLE
Add xml formatter setting to append a space before the self-closed tag end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.0 (08-10-2023)
+
+-   `--tagSpaceBeforeSelfClose` option added to XML Formatter
+
 ## 1.9.1 (07-10-2023)
 
 -   'AMeaningAssumptionGenerator' bugfix

--- a/README.md
+++ b/README.md
@@ -789,6 +789,14 @@ It is possible to pass a parameter if closing tags (">", "/>") should be located
 ui5linter --format --tagEndNewline
 ```
 
+### Add space before a self-closing tag
+
+It is possible to pass a parameter if a space should be added before a self-closing tag ("/>")
+
+```bash
+ui5linter --format --tagSpaceBeforeSelfClose
+```
+
 ---
 
 ## package.json interface

--- a/bin/ui5linter.js
+++ b/bin/ui5linter.js
@@ -42,9 +42,10 @@ const { minimatch } = require("minimatch");
 					return new Promise(resolve => resolve());
 				}
 
-				const bShouldXmlFormatterTagEndByNewline = process.argv.includes("--tagEndNewline")
+				const bShouldXmlFormatterTagEndByNewline = process.argv.includes("--tagEndNewline");
+				const bShouldXmlFormatterTagSpaceBeforeSelfClose = process.argv.includes("--tagSpaceBeforeSelfClose");
 				const document = new TextDocument(XMLFile.content, XMLFile.fsPath);
-				const formatter = new XMLFormatter(parserData.parser, bShouldXmlFormatterTagEndByNewline);
+				const formatter = new XMLFormatter(parserData.parser, bShouldXmlFormatterTagEndByNewline, bShouldXmlFormatterTagSpaceBeforeSelfClose);
 
 				const newContent = formatter.formatDocument(document);
 				if (newContent && newContent !== XMLFile.content) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ui5plugin-linter",
-	"version": "1.9.1",
+	"version": "1.10.0",
 	"description": "UI5 Class linter",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/classes/formatter/xml/XMLFormatter.ts
+++ b/src/classes/formatter/xml/XMLFormatter.ts
@@ -5,10 +5,12 @@ import { IUI5Parser } from "ui5plugin-parser/dist/parser/abstraction/IUI5Parser"
 
 export class XMLFormatter {
 	private readonly _bShouldXmlFormatterTagEndByNewline: boolean = true;
+	private readonly _bShouldXmlFormatterTagSpaceBeforeSelfClose: boolean = true;
 	private readonly _parser: IUI5Parser;
-	constructor(parser: IUI5Parser, bShouldXmlFormatterTagEndByNewline?: boolean) {
+	constructor(parser: IUI5Parser, bShouldXmlFormatterTagEndByNewline?: boolean, bShouldXmlFormatterTagSpaceBeforeSelfClose?: boolean) {
 		this._parser = parser;
 		this._bShouldXmlFormatterTagEndByNewline = bShouldXmlFormatterTagEndByNewline ?? true;
+		this._bShouldXmlFormatterTagSpaceBeforeSelfClose = bShouldXmlFormatterTagSpaceBeforeSelfClose ?? true;
 	}
 
 	formatDocument(document: TextDocument) {
@@ -109,6 +111,10 @@ export class XMLFormatter {
 		if (tagAttributes.length <= 1 || !this._bShouldXmlFormatterTagEndByNewline) {
 			formattedTag = formattedTag.trimEnd();
 			indentation = "";
+
+			if (tagEnd === "/>" && this._bShouldXmlFormatterTagSpaceBeforeSelfClose) {
+				indentation += " ";
+			}
 		}
 
 		formattedTag += `${indentation}${tagEnd}`;


### PR DESCRIPTION
Port of iljapostnovs/VSCodeUI5Plugin#372.

I didn't bother creating an XMLFormatterConfig interface, but I'm sure that'd be useful in the future.

Also, it was fun working on an orange VSCode 😁 (but was that intentional?).