### PR TITLE
Preserve new lines of documents formatted via the XMLFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.0 (08-11-2023)
+
+-   Make XML Formatter preserve newlines
+
 ## 1.10.0 (08-10-2023)
 
 -   `--tagSpaceBeforeSelfClose` option added to XML Formatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.11.0 (08-11-2023)
+## 1.11.0 (10-10-2023)
 
 -   Make XML Formatter preserve newlines
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ui5plugin-linter",
-	"version": "1.9.1",
+	"version": "1.11.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ui5plugin-linter",
-			"version": "1.9.1",
+			"version": "1.11.0",
 			"funding": [
 				{
 					"type": "paypal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ui5plugin-linter",
-	"version": "1.10.0",
+	"version": "1.11.0",
 	"description": "UI5 Class linter",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/classes/formatter/xml/XMLFormatter.ts
+++ b/src/classes/formatter/xml/XMLFormatter.ts
@@ -20,7 +20,9 @@ export class XMLFormatter {
 			return;
 		}
 
-		const newlineEnding = document.getText()
+		const documentNewline = document.getText()
+			.match(/\r?\n/)?.[0] ?? "\n";
+		const documentNewlineEnding = document.getText()
 			.slice(-2)
 			.match(/\r?\n$/)?.[0] ?? "";
 
@@ -40,7 +42,7 @@ export class XMLFormatter {
 			})
 			.reduce(this._removeUnnecessaryTags.bind(this), []);
 
-		return formattedTags.join("\n") + newlineEnding;
+		return formattedTags.join(documentNewline) + documentNewlineEnding;
 	}
 
 	private _removeUnnecessaryTags(accumulator: string[], currentTag: string): string[] {

--- a/src/classes/formatter/xml/XMLFormatter.ts
+++ b/src/classes/formatter/xml/XMLFormatter.ts
@@ -20,6 +20,10 @@ export class XMLFormatter {
 			return;
 		}
 
+		const newlineEnding = document.getText()
+			.slice(-2)
+			.match(/\r?\n$/)?.[0] ?? "";
+
 		let indentationLevel = 0;
 		const formattedTags = allTags
 			.map(currentTag => {
@@ -36,7 +40,7 @@ export class XMLFormatter {
 			})
 			.reduce(this._removeUnnecessaryTags.bind(this), []);
 
-		return formattedTags.join("\n");
+		return formattedTags.join("\n") + newlineEnding;
 	}
 
 	private _removeUnnecessaryTags(accumulator: string[], currentTag: string): string[] {


### PR DESCRIPTION
- Preserve newline format (CRLF or LF). Default to LF if we cannot determine it.
- Preserve ending newline, if present.